### PR TITLE
Add spider para histórico do item da nota de empenho

### DIFF
--- a/schema/despesa_item_empenho_historico.csv
+++ b/schema/despesa_item_empenho_historico.csv
@@ -1,0 +1,9 @@
+field_name,field_type,internal_field_type,original_name
+id_empenho,integer,integer,Id Empenho
+codigo_empenho,integer,text,Código Empenho
+sequencial,integer,text,Sequencial
+tipo_operacao,text,text,Tipo Operação
+data_operacao,text,text,Data Operação
+quantidade_item,decimal,money_real,Quantidade Item
+valor_unitario_item,decimal,money_real,Valor Unitário Item
+valor_total_item,decimal,money_real,Valor Total Item

--- a/transparenciagovbr/spiders/despesa_item_empenho.py
+++ b/transparenciagovbr/spiders/despesa_item_empenho.py
@@ -110,3 +110,12 @@ class DespesaEmpenhoSpider(DespesaMixin, TransparenciaBaseSpider):
     publish_frequency = "daily"
     filename_suffix = "_Despesas_Empenho.csv"
     schema_filename = "despesa_empenho.csv"
+
+class Spider(DespesaMixin, TransparenciaBaseSpider):
+    name = "despesa_item_historico"
+    base_url = "http://transparencia.gov.br/download-de-dados/despesas/{year}{month:02d}{day:02d}"
+    start_date = datetime.date(2021, 1, 1)
+    end_date = today()
+    publish_frequency = "daily"
+    filename_suffix = "_Despesas_ItemEmpenhoHistorico.csv"
+    schema_filename = "despesa_item_empenho_historico.csv"


### PR DESCRIPTION
A partir de 2021 cada item de uma nota de empenho possui um histórico, com inclusões, reforços e anulações de quantidades e valores. Com isso, precisamos baixar um novo csv para calcular a quantidade e o valor comprado de cada item. Esse PR adiciona o spider necessário.